### PR TITLE
fix(aks): set service_cidr to avoid overlap with VNet subnets

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -28,14 +28,14 @@ module "primary_network" {
   vnet_name           = "roadmap-maker-primary-vnet"
   location            = local.primary_region
   resource_group_name = module.resource_groups[local.primary_region].name
-  address_space       = ["10.1.0.0/16"]
+  address_space       = ["10.0.0.0/16"]
 
   subnets = {
     aks = {
-      address_prefixes = ["10.1.1.0/24"]
+      address_prefixes = ["10.0.1.0/24"]
     }
     app = {
-      address_prefixes = ["10.1.2.0/24"]
+      address_prefixes = ["10.0.2.0/24"]
     }
   }
 
@@ -68,6 +68,9 @@ module "primary_aks" {
   network_plugin = "azure"
   network_policy = "azure"
   vnet_subnet_id = module.primary_network.subnet_ids["aks"]
+
+  # configure service CIDR 
+  service_cidr = "172.16.0.0/16"
 
   tags = merge(local.common_tags, {
     cluster-type = "primary"
@@ -137,6 +140,6 @@ resource "azurerm_postgresql_flexible_server_firewall_rule" "azure_services" {
 resource "azurerm_postgresql_flexible_server_firewall_rule" "aks_subnet" {
   name             = "AllowAKSSubnet"
   server_id        = azurerm_postgresql_flexible_server.primary.id
-  start_ip_address = "10.1.1.0"
-  end_ip_address   = "10.1.1.255"
+  start_ip_address = "10.0.1.0"
+  end_ip_address   = "10.0.1.255"
 }

--- a/infra/terraform/modules/aks/main.tf
+++ b/infra/terraform/modules/aks/main.tf
@@ -6,16 +6,16 @@ resource "azurerm_kubernetes_cluster" "default" {
   kubernetes_version  = var.kubernetes_version
 
   default_node_pool {
-    name                = "default"
-    node_count          = var.node_count
-    vm_size             = var.node_vm_size
-    min_count           = var.enable_auto_scaling ? var.min_count : null
-    max_count           = var.enable_auto_scaling ? var.max_count : null
-    max_pods            = var.max_pods
-    os_disk_size_gb     = var.os_disk_size_gb
-    type                = "VirtualMachineScaleSets"
-    vnet_subnet_id      = var.vnet_subnet_id
-    
+    name            = "default"
+    node_count      = var.node_count
+    vm_size         = var.node_vm_size
+    min_count       = var.enable_auto_scaling ? var.min_count : null
+    max_count       = var.enable_auto_scaling ? var.max_count : null
+    max_pods        = var.max_pods
+    os_disk_size_gb = var.os_disk_size_gb
+    type            = "VirtualMachineScaleSets"
+    vnet_subnet_id  = var.vnet_subnet_id
+
     tags = var.tags
   }
 
@@ -25,16 +25,17 @@ resource "azurerm_kubernetes_cluster" "default" {
   }
 
   network_profile {
-    network_plugin = var.network_plugin  # "azure"
-    network_policy = var.network_policy  # "azure"
+    network_plugin = var.network_plugin # "azure"
+    network_policy = var.network_policy # "azure"
+    service_cidr   = var.service_cidr
   }
 
   # Enable Azure Policy Add-on
   azure_policy_enabled = true
-  
+
   # Enable HTTP Application Routing (for development)
   http_application_routing_enabled = false
-  
+
   # Enable role-based access control
   role_based_access_control_enabled = true
 

--- a/infra/terraform/modules/aks/variables.tf
+++ b/infra/terraform/modules/aks/variables.tf
@@ -22,7 +22,7 @@ variable "kubernetes_version" {
   description = "Kubernetes version for the AKS cluster"
   type        = string
   default     = "1.32.5"
-  
+
 }
 
 variable "node_count" {
@@ -89,4 +89,10 @@ variable "vnet_subnet_id" {
   description = "Subnet ID for the AKS cluster"
   type        = string
   default     = null
+}
+
+variable "service_cidr" {
+  description = "Service CIDR for Kubernetes services"
+  type        = string
+  default     = "172.16.0.0/16"
 }


### PR DESCRIPTION
- Add service_cidr variable to AKS module network_profile (differ from subnet CIDR)
- Reuse the old subnet (to avoid NetcfgSubnetRangeOutsideVnet)